### PR TITLE
Flexibility of list-type field definitions

### DIFF
--- a/fitencode/__init__.py
+++ b/fitencode/__init__.py
@@ -26,8 +26,16 @@ class FitEncode:
         header_crc = self._crc(0, header)
         return header + pack('<H', header_crc)
 
-    def add_definition(self, mesg: messages.Message):
-        self.add_record(mesg.definition)
+    def add_definition(self, mesg: messages.Message, size: dict = None):
+        """ Add a field definition record.
+
+        :param size: A dict can be given the key of the field name and
+                     the value of the field size to change the field size.
+        """
+        if size:
+            self.add_record(mesg.definition_override_by(size))
+        else:
+            self.add_record(mesg.definition)
 
     def add_record(self, record: bytes):
         self.length += self.buffer.write(record)

--- a/fitencode/messages.py
+++ b/fitencode/messages.py
@@ -27,6 +27,21 @@ class Message:
                       reserved, is_big_endian, self.mesg_num, len(fields_))
         return header + b''.join(fields_)
 
+    def definition_override_by(self, size: dict) -> bytes:
+        # Field definitions of different sizes
+        fields_ = []
+        for name, f in self.fields:
+            if name in size:
+                fields_.append(pack('BBB', f.field_def, size[name], f.field_type))
+            else:
+                fields_.append(f.definition)
+        reserved = 0
+        is_big_endian = 1
+        header = pack('>BBBHB',
+                      MESSAGE_DEFINITION | self.local_mesg_num,
+                      reserved, is_big_endian, self.mesg_num, len(fields_))
+        return header + b''.join(fields_)
+
     def pack(self, **kwargs) -> bytes:
         contents = list()
         for name, field in self.fields:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fit-encode
-version = 0.0.2
+version = 0.0.3
 description =  Python library for ANT/Garmin .FIT file encode.
 long_description = file: README.md
 classifiers =
@@ -10,7 +10,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.9
 author = Hiroyuki OYAMA
-author_email = oyama@sportsengineering.co.jp
+author_email = hiroyuki.oyama@japanhpc.com
 
 [options]
 package_dir=

--- a/tests/test_changing_list_size.py
+++ b/tests/test_changing_list_size.py
@@ -1,0 +1,75 @@
+from struct import pack
+import unittest
+
+from fitencode import FitEncode, messages, fields
+
+
+class FileId(messages.FileId):
+    manufacturer = messages.FileId.manufacturer
+    type = messages.FileId.type
+    product = messages.FileId.product
+    serial_number = messages.FileId.serial_number
+    product_name = messages.FileId.product_name
+
+
+class ArrayUint16Field(fields.Uint16Field):
+    field_type = 0x84
+    pack_format = '>H'
+
+    def pack(self, value: list) -> bytes:
+        pack_format = f">{len(value)}H"
+        return pack(pack_format, *value)
+
+
+class AccelerometerData(messages.Message):
+    mesg_num = 165
+    local_mesg_num = 3
+
+    sample_time_offset = ArrayUint16Field(field_def=1, size=2 * 30)  # unit [ms]
+
+
+
+class ChangingListSizeTestCase(unittest.TestCase):
+    def test_define_changing_list_size(self):
+        fit = FitEncode()
+        file_id = FileId()
+        fit.add_definition(file_id)
+        fit.add_record(file_id.pack(manufacturer=0x000F,
+                                    type=0x04,
+                                    product=0x0001,
+                                    serial_number=1,
+                                    product_name='TEST'))
+        accel = AccelerometerData()
+        fit.add_definition(accel)
+
+        time_offset = list(range(0, 30))
+        fit.add_record(accel.pack(sample_time_offset=time_offset))
+
+        time_offset = list(range(0, 3))
+
+        fit.add_definition(accel, size={'sample_time_offset': 2*3})
+        fit.add_record(accel.pack(sample_time_offset=time_offset))
+
+        fit.add_definition(accel)
+        time_offset = list(range(30, 60))
+        fit.add_record(accel.pack(sample_time_offset=time_offset))
+        fit.finish()
+        self.assertEqual(
+            (b'\x0e\x10\x1c\x08\xcf\x00\x00\x00.FIT\x89\xff@\x00'
+             b'\x01\x00\x00\x05\x01\x02\x84\x00\x01\x00\x02\x02\x84\x03\x04\x8c'
+             b'\x08\x14\x07\x00\x00\x0f\x04\x00\x01\x00\x00\x00\x01TEST'
+             b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00C'
+             b'\x00\x01\x00\xa5\x01\x01<\x84\x03\x00\x00\x00\x01\x00\x02\x00'
+             b'\x03\x00\x04\x00\x05\x00\x06\x00\x07\x00\x08\x00\t\x00\n\x00'
+             b'\x0b\x00\x0c\x00\r\x00\x0e\x00\x0f\x00\x10\x00\x11\x00\x12\x00'
+             b'\x13\x00\x14\x00\x15\x00\x16\x00\x17\x00\x18\x00\x19\x00\x1a\x00'
+             b'\x1b\x00\x1c\x00\x1dC\x00\x01\x00\xa5\x01\x01\x06\x84\x03\x00\x00'
+             b'\x00\x01\x00\x02C\x00\x01\x00\xa5\x01\x01<\x84\x03\x00\x1e\x00'
+             b'\x1f\x00 \x00!\x00"\x00#\x00$\x00%\x00&\x00\'\x00(\x00)\x00*\x00+'
+             b'\x00,\x00-\x00.\x00/\x000\x001\x002\x003\x004\x005\x006\x007\x008'
+             b'\x009\x00:\x00;b~'),
+            fit.buffer.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If the length of a list-type field is not fixed and changes at runtime, the field definition must be added to .FIT each time. To facilitate creation of resized field definitions, the field name and size dictionary type arguments are now accepted.

```
time_offset = [0, 1, 2]
fit.add_definition(accel,
                   size={'sample_time_offset': 2 * len(time_offset)})
fit.add_record(accel.pack(sample_time_offset=time_offset))
```